### PR TITLE
Chapter 002 remove docker troubleshooting

### DIFF
--- a/chapters/001-getting-started/README.md
+++ b/chapters/001-getting-started/README.md
@@ -65,7 +65,7 @@ root@3daaaf641c2d:/# ip addr
        valid_lft forever preferred_lft forever
 ```
 
-There's a lot going on here, and we'll get more familiar with this output in future chapters. But, for now, what we're seeing is 2 network [interfaces](../glossary.md#interfaces) on `pippin`, one for loopback, `lo`, which is used in networking for routing queries back to the machine that made the initial query. The other interface, `eth0` shows us that `pippin` already has an IP address, `172.17.0.2`, on an existing network, `172.17.0.2/16`. The exact address may be different on your machine, but the principles are the same.
+There's a lot going on here, and we'll get more familiar with this output in future chapters. But, for now, what we're seeing is 2 network [interfaces](../glossary.md#interface) on `pippin`, one for loopback, `lo`, which is used in networking for routing queries back to the machine that made the initial query. The other interface, `eth0` shows us that `pippin` already has an IP address, `172.17.0.2`, on an existing network, `172.17.0.2/16`. The exact address may be different on your machine, but the principles are the same.
 
 Uh oh... Let's hopon `boudi` and see if that machine is on the same network:
 
@@ -286,13 +286,11 @@ docker system prune
 
 ### Cannot edit IP addresses?
 
-tl;dr We initially could not edit our IP addresses for the containers within the network. The solution for the problem was adding the permission `--cap-add=NET_ADMIN` when running `docker run` to get docker to allow us to be able to edit them.
-
-It doesn't seem like it's possible to manually configure the IP address settings for a container. For example,
+tl;dr We initially could not edit our IP addresses for the containers within the network:
 
 ```bash
 / # ip addr add 10.1.1.3/24 dev eth1
 ip: RTNETLINK answers: Operation not permitted
 ```
 
-☝️ it's not possible to add an IP address to a running machine. Similarly, `ip addr del` also fails with an `Operation not permitted` error.
+The solution for the problem was adding the permission `--cap-add=NET_ADMIN` when running `docker run` to get docker to allow us to be able to edit them.

--- a/chapters/002-smol-internet/README.md
+++ b/chapters/002-smol-internet/README.md
@@ -125,7 +125,7 @@ The only network `boudi` knows about on its routing table is its own `squasheeba
 
 ## Make those networks communicate with each other
 
-How do machines communicate across networks? Well, first they need to have a router. Sure, docker has its own built in router, but we want to build our own.  What is a router, but  another machine on the network. A router just has 2 special properties that make it a router instead of just a regular machine on the network:
+How do machines communicate across networks? Well, first they need to have a router. Sure, docker has its own built in router, but we want to build our own.  What is a router, but another machine on the network. A router just has 2 special properties that make it a router instead of just a regular machine on the network:
 
 * an interface on more than one network
 * the ability to forward packets that are not destined for itself to other machines
@@ -232,7 +232,7 @@ Here we see the incoming `ping` or `ICMP echo request`. The source machine is `1
 
 > **What's with those ARP requests?**
 
-YOu may or may not see in your own session some odd looking packets identified as `ARP` in the tcpdump:
+You may or may not see in your own session some odd looking packets identified as `ARP` in the tcpdump:
 
 ```bash
 18:53:54.166970 ARP, Request who-has 10.1.2.3 tell 10.1.2.2, length 28
@@ -241,7 +241,7 @@ YOu may or may not see in your own session some odd looking packets identified a
 18:53:54.167168 ARP, Reply 10.1.2.3 is-at 02:42:0a:01:02:03, length 28
 ```
 
-We go over this in more detail in [ip-and-mac-addresses.md in the appendix](../appendix/ip-and-mac-addresses.md), but let's look at a high level at what's going on here. IP addresses, like `10.1.2.3`, are used by machines for identifying where packets should be routed across an internet. So what we've been working with so far is designed to help machines communicate when there are multiple networks. HOWEVER. Within a network, machines are not identified by an IP address, but instead by a MAC address. In order for packets to be forwarded from one machine on a network to another machine on the same network, each machine needs to discover the MAC address that corresponds to the IP address identified in the packets. ARP, or Address Resolution Protocol, is the process by which this is done.
+We go over this in more detail in [ip-and-mac-addresses.md in the appendix](../appendix/ip-and-mac-addresses.md), but let's look at a high level at what's going on here. IP addresses, like `10.1.2.3`, are used by machines for identifying where packets should be routed across an internet. So what we've been working with so far is designed to help machines communicate when there are multiple networks. HOWEVER. Within a network, machines are not identified by an IP address, but instead by a MAC address. In order for packets to be sent from one machine on a network to another machine on the same network, each machine needs to discover the MAC address that corresponds to the IP address identified in the packets. ARP, or Address Resolution Protocol, is the process by which this is done.
 
 Let's read what's happening with the `ARP` requests we see above:
 
@@ -295,13 +295,15 @@ Lovely! This is because, while `boudi` has an interface on the `doggonet` networ
 
 ### Make `tara` ping hosts on the `squasheeba` network
 
-The first thing we need to do is add a route from `tara` to the `squasheeba` network via `boudi`. Because `boudi` has routes to both `doggonet` and `squasheeba`, `boudi` can act as the gateway between the two. We can manage routes on our machines using the `ip route` command:
+The first thing we need to do is add a route from `tara` to the `squasheeba` network via `boudi`. Because `boudi` has routes to both `doggonet` and `squasheeba`, `boudi` can act as the router between the two. We can manage routes on our machines using the `ip route` command:
 
 ```bash
 root@tara:/# ip route add 10.1.1.0/24 via 10.1.2.3
 ```
 
-This command defines the network, `10.1.1.0/24` and then says that routes to that network should use a machine that exists on a network it has an interface on, namely, `boudi` at `10.1.2.3`. Now, if we check the routes that `tara` knows about, we'll see the route defined in `tara`'s routing table:
+This command identifies the network, `10.1.1.0/24` (a.k.a. "squasheeba") and then says: "Any time you have a packet for this network, you should send it to `10.1.2.3` (a.k.a. `boudi`), cuz that dude knows all about it."
+
+Now, if we check the routes that `tara` knows about, we'll see the route defined in `tara`'s routing table:
 
 ```bash
 root@tara:/# ip route

--- a/chapters/002-smol-internet/docker-compose.yml
+++ b/chapters/002-smol-internet/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.0"
 services:
   boudi:
     build: .
+    hostname: boudi
     networks:
       squasheeba:
         ipv4_address: 10.1.1.3
@@ -9,6 +10,7 @@ services:
       - NET_ADMIN
   pippin:
     build: .
+    hostname: pippin
     networks:
       squasheeba:
         ipv4_address: 10.1.1.2

--- a/chapters/002-smol-internet/final/start-up.sh
+++ b/chapters/002-smol-internet/final/start-up.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+/usr/sbin/ip route delete default
+
+case $HOSTNAME in
+  (pippin) ip route add 10.1.2.0/24 via 10.1.1.3;;
+  (tara) ip route add 10.1.1.0/24 via 10.1.2.3;;
+esac
+
+/bin/sleep infinity

--- a/chapters/002-smol-internet/init/start-up.sh
+++ b/chapters/002-smol-internet/init/start-up.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+/usr/sbin/ip route delete default
+
 /bin/sleep infinity

--- a/chapters/appendix/prefixes-and-subnet-masks.md
+++ b/chapters/appendix/prefixes-and-subnet-masks.md
@@ -147,7 +147,7 @@ This might sound like gibberish to begin with. Don't worry! We'll spell it out i
 
 Let's go through an example of this. We're looking at one router on the Internet, and let's say it has the following routing table:
 
-```
+```none
 Route 1: 10.1.0.0/24
 Route 2: 10.2.0.0/23 <== notice the /23! tricky!
 Route 3: 10.3.3.0/24
@@ -168,19 +168,19 @@ First, we apply the subnet mask of that route to the destination IP address of t
 
 The subnet mask, that "/24" on the route, represents 24 bits of mask. Said another way, it has 24 "1"s turned on, starting from the left of the binary number, like this:
 
-```
+```none
 11111111.11111111.11111111.00000000 <== 24 "1"s
 ```
 
 Next, we convert each octet of the destination IP address to bits, so `10.2.1.4` becomes:
 
-```
+```none
 00001010.00000010.00000001.00000100
 ```
 
 To apply the binary AND operation between these numbers is simple: line them up and go bit-by-bit: if **both** bits are `1`, then the result is a `1`. Otherwise, the result is a `0`:
 
-```
+```none
 subnet mask:         11111111.11111111.11111111.00000000
 destination IP:      00001010.00000010.00000001.00000100
    AND               ===================================
@@ -207,7 +207,7 @@ Okay, the first route didn’t work out. But we’re not frightened. We have mor
 
 We apply the subnet mask (`/23`) to the destination IP address (`10.2.1.4`):
 
-```
+```none
 subnet mask:         11111111.11111111.11111110.00000000 <==  23 1's!
 network address:     00001010.00000010.00000001.00000100
  AND                 ===================================
@@ -279,7 +279,7 @@ Did you notice the pattern there? Eh? Eh?! The values at the upper end of the IP
 
 All we’re doing is turning on the next value in our 8-bit binary number!
 
-```
+```none
 0000 0000 = 0
 0000 0001 = 1
 0000 0010 = 2
@@ -306,7 +306,7 @@ Using what you know now, see if you can figure out the answers to the following 
 * What is the subnet mask for a network with a single address?
 * Using the routing table below, which route would a router pick for `10.4.4.18`?
 
-```
+```bash
 Route 1: 10.1.0.0/24
 Route 2: 10.2.0.0/23
 Route 3: 10.3.3.0/24

--- a/chapters/glossary.md
+++ b/chapters/glossary.md
@@ -55,13 +55,17 @@ Typically a network will have a "network address" which (if we're using version 
 
 Sometimes when people use the term "network," they mean "internetwork." Since "internetwork" is a lot of syllables, it's a lot easier to just shorten the word.
 
-## router (also known as a `gateway`)
+## packets (a.k.a `IP packets`)
+
+All traffic on an internet is wrapped up in IP packets. IP packets provide a header that contains a bit of metadata that is necessary to be able to correctly route and manage the data container within the packet.
+
+## router (a.k.a `gateway`)
 
 A router is any machine whose purpose is to connect networks together. It does so by forwarding packets further toward their destination. Each router has a routing table which serves much like a sign post on a highway: it tells the router where to send packets next on their way to their final destination. Each router makes decisions on its own for the most efficient way to send the packet to its destination. The internet, as we know today, is not possible without numerous routers facilitating the requests.
 
 ## routing table
 
-A routing table is a list of known network IP address ranges and potentially a default gateway that lives on every machine connected to an internet. The routing table is used to know how to send packets across an internet from a source machine to a destination machine. The routing table shows network prefixes and subnets and associates them with a next hop that can forward packets towards the destination. If the routing table does not have a matching route for the destination IP address, the request can be sent out the default gateway in the hopes that another machine on that internet will know how to get the packets to their destination.
+A routing table is a list of known network IP address ranges, and every machine connected to an internet has a routing table to reference. Machines use routing tables to determine what the next [hop](#hop) should be when they're sending [packets](#packets) towards a destination IP address. If the routing table does not have a matching route for the destination IP address, the request can be sent out the default gateway in the hopes that another machine on that internet will know how to get the packets to their destination. Check [prefixes-and-subnet-masks.md in the appendix](./appendix/prefixes-and-subnet-masks.md) for more details on how routing tables work.
 
 ## server
 

--- a/chapters/glossary.md
+++ b/chapters/glossary.md
@@ -59,6 +59,10 @@ Sometimes when people use the term "network," they mean "internetwork." Since "i
 
 A router is any machine whose purpose is to connect networks together. It does so by forwarding packets further toward their destination. Each router has a routing table which serves much like a sign post on a highway: it tells the router where to send packets next on their way to their final destination. Each router makes decisions on its own for the most efficient way to send the packet to its destination. The internet, as we know today, is not possible without numerous routers facilitating the requests.
 
+## routing table
+
+A routing table is a list of known network IP address ranges and potentially a default gateway that lives on every machine connected to an internet. The routing table is used to know how to send packets across an internet from a source machine to a destination machine. The routing table shows network prefixes and subnets and associates them with a next hop that can forward packets towards the destination. If the routing table does not have a matching route for the destination IP address, the request can be sent out the default gateway in the hopes that another machine on that internet will know how to get the packets to their destination.
+
 ## server
 
 A server is any machine whose purpose is to serve a network request to a client. If the server fails to serve the request, it can return an appropriate error back to the client.


### PR DESCRIPTION
instead of teaching people how to figure out why and how docker is forcing us into certain patterns, let's just remove all the docker troubleshooting references and make a chapter that shows strictly how to setup and manage an internetwork.