### PR TITLE
promote the command-reference-guide to the same level as glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You will need to install [colima](https://smallsharpsoftwaretools.com/tutorials/
 
 ## DISCLAIMERS
 
-We've put some effort into [explaining the commands](./chapters/000-getting-started/command-reference-guide.md) that we're using. However, if we use a command with a flag that doesn't have explanation, check the command's `help` for more details; e.g. `ping --help`. Alternatively, check the command's manpage; e.g. `man ping`.
+We've put some effort into [explaining the commands](./chapters/command-reference-guide.md) that we're using. However, if we use a command with a flag that doesn't have explanation, check the command's `help` for more details; e.g. `ping --help`. Alternatively, check the command's manpage; e.g. `man ping`.
 
 ## Stages of the project
 

--- a/chapters/001-Routing/1.1-getting-started/README.md
+++ b/chapters/001-Routing/1.1-getting-started/README.md
@@ -41,7 +41,7 @@ To do so:
 
 ## Build a Network
 
-Now that we've got some machines up and running, let's network them together! To start with, let's just verify that `boudi` and `pippin` can't already talk to each other. We can check this by running a very simple program called `ping`. We can provide `ping` with an IP address and it will see if it can send a simple request to the machine at the address provided. If a machine receives the type of request `ping` sends, it will send a response back. We're expecting there to be no response when `boudi` tries to `ping` `pippin`.
+Now that we've got some machines up and running, let's network them together! To start with, let's just verify that `boudi` and `pippin` can't already talk to each other. We can check this by running a very simple program called [`ping`](../../command-reference-guide.md#ping). We can provide `ping` with an IP address and it will see if it can send a simple request to the machine at the address provided. If a machine receives the type of request `ping` sends, it will send a response back. We're expecting there to be no response when `boudi` tries to `ping` `pippin`.
 
 ### Check the current state
 
@@ -51,7 +51,7 @@ Let's start by hopping onto `pippin`:
 docker exec -it pippin /bin/bash
 ```
 
-In order for `boudi` to `ping` `pippin`, we'll need to get `pippin`'s IP address. Let's start by seeing what IP address configuration Docker automatically created for `pippin` when it created the machine. There's a very simple command with a lot of confusing output that we can run to get this: `ip addr`.
+In order for `boudi` to `ping` `pippin`, we'll need to get `pippin`'s IP address. Let's start by seeing what IP address configuration Docker automatically created for `pippin` when it created the machine. There's a very simple command with a lot of confusing output that we can run to get this: [`ip addr`](../../command-reference-guide.md#ip-addr).
 
 ``` bash
 root@3daaaf641c2d:/# ip addr
@@ -147,7 +147,7 @@ But wait... why are we ending our addresses with `.2` and `.3`? Why aren't we st
 
 ### Test the network connection
 
-Here, we're going to start exploring with a networking tool called `tcpdump`. `tcpdump` "sniffs" ethernet frames on the network interface identified in the command. What we'll end up running on `pippin` is:
+Here, we're going to start exploring with a networking tool called [`tcpdump`](../../command-reference-guide.md#tcpdump). `tcpdump` "sniffs" ethernet frames on the network interface identified in the command. What we'll end up running on `pippin` is:
 
 ```bash
 tcpdump -ni eth0

--- a/chapters/001-Routing/1.2-smol-internet/README.md
+++ b/chapters/001-Routing/1.2-smol-internet/README.md
@@ -122,7 +122,7 @@ ping: connect: Network is unreachable
 
 Fantastic! This error message is telling us is that `boudi` doesn't know how to send packets to a machine on the `10.1.2.0/24` network. The way that machines communicate with each other across networks is by matching the destination IP address to a network address range in their [routing table](../glossary.md#routing-table). The routing table will have a list of network address ranges defined and will associate those address ranges with a "next hop", or another machine that it thinks will get the packets closer to their destination.
 
-If we look at the routing table for `boudi`, we can see that there is no entry for the `10.1.2.0/24` network:
+We can look at the routing table on our machines using the [`ip route` command](../../command-reference-guide.md#ip-route). If we look at the routing table for `boudi`, we can see that there is no entry for the `10.1.2.0/24` network:
 
 ```bash
 root@boudi:/# ip route

--- a/chapters/Useful-tooling/traceroute/README.md
+++ b/chapters/Useful-tooling/traceroute/README.md
@@ -2,7 +2,7 @@
 
 ## Goals for this section
 
-Explore how traceroute gives us network topology so we can see how the machines we're creating are communicating with each other.
+Explore how [traceroute](../../command-reference-guide.md#traceroute) gives us network topology so we can see how the machines we're creating are communicating with each other.
 
 We'll be exploring traceroute using the internet we created in Chapter 002:
 
@@ -138,7 +138,7 @@ As soon as `traceroute` gets that `ICMP udp port unreachable` message, it knows 
 
 ### Let's break that shit
 
-Now we know what to expect when traceroute is successfully navigating a path from the initiator machine to the destination machine. Let's see what happens when that path is broken. We added a new software to our Dockerfile, `iptables`. `iptables` is a powerful tool for managing network traffic. If you want to play with more options after you finish this introduction, [check out this blog post](https://www.cyberciti.biz/tips/linux-iptables-9-allow-icmp-ping.html). At a basic level, `iptables` allows you to write rules for handling packets that are incoming, forwarding, or outgoing. You can see a list of your current rules with `iptables -L`:
+Now we know what to expect when traceroute is successfully navigating a path from the initiator machine to the destination machine. Let's see what happens when that path is broken. We added a new software to our Dockerfile, [`iptables`](../../command-reference-guide.md#iptables). `iptables` is a powerful tool for managing network traffic. If you want to play with more options after you finish this introduction, [check out this blog post](https://www.cyberciti.biz/tips/linux-iptables-9-allow-icmp-ping.html). At a basic level, `iptables` allows you to write rules for handling packets that are incoming, forwarding, or outgoing. You can see a list of your current rules with `iptables -L`:
 
 ```bash
 root@pippin:/# iptables -L

--- a/chapters/command-reference-guide.md
+++ b/chapters/command-reference-guide.md
@@ -1,4 +1,5 @@
 # Command Reference Guide
+
 - [Command Reference Guide](#command-reference-guide)
   - [dig](#dig)
   - [ip](#ip)
@@ -11,8 +12,6 @@
   - [tcpdump](#tcpdump)
   - [traceroute](#traceroute)
 
-<!-- TODO: MOVE THIS FILE SO IT LIVES NEXT TO THE GLOSSARY -->
-
 We provide a lot of commands in creating, exploring, and troubleshooting our internet. It's easy to forget which command does what. Here's a reference guide to help you remember the commands we've used and what they do.
 
 This is an incomplete list of flags and abilities. For each of these commands, please use the `-h` flag to get help on how to use them. If you want a detailed handbook on the full capabilities of a command, try `man <command>` to view the manpage. Also, please keep in mind that these commands are for a Linux operating system. If you want to run similar commands from a Mac or Windows OS, you'll need to look up their equivalent.
@@ -21,7 +20,9 @@ Julia Evans, @bork, has written [a number of comics](https://wizardzines.com/com
 
 ## dig
 
-This is a command-line tool that allows you to check name-resolution. 
+[@bork's comic](https://wizardzines.com/comics/dig/) giving some guidance on using `dig`.
+
+This is a command-line tool that allows you to check name-resolution.
 
 > Example commands:
 
@@ -39,21 +40,21 @@ The `ip` command is a tool for viewing and managing network configurations. It h
 
 `ip addr` gives us view into the network interfaces available on a machine. It displays all available interfaces on a machine, even ones that are not currently active. Beyond the interface, `ip addr` has information about both layer 2 (Ethernet) and layer 3 (IP), which allows us to understand more about which machine is sending packets from where.
 
-> Example commands
+> Example commands:
 
-* `ip addr` - view all interfaces on a machine
-* `ip addr del <ip_prefix_and_subnet> dev <interface>` - delete an interface on a machine
-* `ip addr add <ip_prefix_and_subnet> dev <interface>` - add an interface for a network subnet on a machine
+- `ip addr` - view all interfaces on a machine
+- `ip addr del <ip_prefix_and_subnet> dev <interface>` - delete an interface on a machine
+- `ip addr add <ip_prefix_and_subnet> dev <interface>` - add an interface for a network subnet on a machine
 
 ### ip route
 
 `ip route` displays and manages the routing table on the machine. The routing table is built out of routes defined on active interfaces. `ip route` deals entirely with layer 3 (IP) information.
 
-> Example commands
+> Example commands:
 
-* `ip route` - show the routing table on a machine
-* `ip route add <ip_prefix_and_subnet> via <ip_address>` - add a route to the routing table and point to a machine who will forward the packets further on their route to the destination
-* `ip route delete <ip_prefix_and_subnet>` - delete a route from the routing table
+- `ip route` - show the routing table on a machine
+- `ip route add <ip_prefix_and_subnet> via <ip_address>` - add a route to the routing table and point to a machine who will forward the packets further on their route to the destination
+- `ip route delete <ip_prefix_and_subnet>` - delete a route from the routing table
 
 ## iptables
 
@@ -63,14 +64,22 @@ The `ip` command is a tool for viewing and managing network configurations. It h
 
 > Commands used in this guide
 
-* `iptables -L` - show the list of all rules applied to packets processed by the machine
-* `iptables -A OUTPUT -p icmp --icmp-type port-unreachable -j DROP` - generate a new rule to drop any ICMP port unreachable packets
-  * `-A OUTPUT`: append a rule to `OUTPUT`, which will only impact any outgoing packets
-  * `-p icmp`: only apply this rule to `icmp` requests
-  * `icmp-type port-unreachable`: specifically, only apply this rule to `ICMP port unreachable` responses
-  * `-j DROP`: `DROP`, or don't send, any packet that matches this rule
+- `iptables -L` - show the list of all rules applied to packets processed by the machine
+- `iptables -A OUTPUT -p icmp --icmp-type port-unreachable -j DROP` - generate a new rule to drop any ICMP port unreachable packets
+  - `-A OUTPUT`: append a rule to `OUTPUT`, which will only impact any outgoing packets
+  - `-p icmp`: only apply this rule to `icmp` requests
+  - `icmp-type port-unreachable`: specifically, only apply this rule to `ICMP port unreachable` responses
+  - `-j DROP`: `DROP`, or don't send, any packet that matches this rule
 
 ## netstat
+
+`netstat` provides a list of all software that is listening for network connections on a machine.
+
+> Example command:
+
+```bash
+netstat -lnp
+```
 
 ## ping
 
@@ -78,9 +87,9 @@ The `ip` command is a tool for viewing and managing network configurations. It h
 
 `ping` is a tool that sends ICMP echo request packets to a specified IP address. A machine on that IP address will respond with ICMP echo response packets as long as:
 
-* there is a machine configured on that IP address
-* there are routes from the client issuing the `ping` to and from the machine configured on that IP address
-* the machine configured on that IP address doesn't have configuration settings telling it to ignore ICMP packets
+- there is a machine configured on that IP address
+- there are routes from the client issuing the `ping` to and from the machine configured on that IP address
+- the machine configured on that IP address doesn't have configuration settings telling it to ignore ICMP packets
 
 > Example command:
 
@@ -90,8 +99,8 @@ ping -c 2 <some_ip_address>
 
 > Helpful flags:
 
-* `-c <some_number>`: Count. Send a specific number of ICMP echo requests. `ping` will wait until its received the ICMP echo response for each request, then exit the program.
-* `-w <some_number>`: Wait. Keep sending ICMP echo requests until the time limit in seconds indicated by the number has passed. `ping` does not wait for the ICMP echo responses.
+- `-c <some_number>`: Count. Send a specific number of ICMP echo requests. `ping` will wait until its received the ICMP echo response for each request, then exit the program.
+- `-w <some_number>`: Wait. Keep sending ICMP echo requests until the time limit in seconds indicated by the number has passed. `ping` does not wait for the ICMP echo responses.
 
 ## ps
 
@@ -117,15 +126,15 @@ tcpdump -ni eth1
 
 > Helpful flags:
 
-* `-e`: Show MAC addresses for each line.
-* `-i <interface_name>`: Select a specific interface.
-* `-n`: Don't convert addresses (e.g., host addresses, port numbers, etc.) to names.
+- `-e`: Show MAC addresses for each line.
+- `-i <interface_name>`: Select a specific interface.
+- `-n`: Don't convert addresses (e.g., host addresses, port numbers, etc.) to names.
 
 ## traceroute
 
 [@bork's comic](https://wizardzines.com/comics/ping/) explaining `ping` and `traceroute`.
 
-`traceroute` is a network analysis tool that shows path a packet takes from the initiator of a request (i.e. a client) to the destination IP. This is done through sending single packets that have a preset `ttl` in the IP header. The `ttl` in IP context does not refer to a specific _time_ to live, instead, it is the maximum number of hops a packet is allowed to traverse before a router should drop it.
+`traceroute` is a network analysis tool that shows path a packet takes from the initiator of a request (i.e. a client) to the destination IP. This is done through sending single packets that have a preset `ttl` in the IP header. The `ttl` in IP context does not refer to a specific *time* to live, instead, it is the maximum number of hops a packet is allowed to traverse before a router should drop it.
 
 > Example command:
 

--- a/chapters/name-resolution/3-nr-simple-dns/README.md
+++ b/chapters/name-resolution/3-nr-simple-dns/README.md
@@ -168,7 +168,7 @@ Once you've confirmed that it's working properly, you can either leave Knot runn
 /usr/sbin/knotd -c /config/knot.conf --daemonize
 ```
 
-Sweet, now that we have told knot to start up with the configuration in place, let's make sure that it is indeed listening for DNS queries. We can do that with the help of [`netstat`](../../000-getting-started/command-reference-guide.md#netstat) command. In your `host-dns` container, run the following:
+Sweet, now that we have told knot to start up with the configuration in place, let's make sure that it is indeed listening for DNS queries. We can do that with the help of [`netstat` command](../../command-reference-guide.md#netstat). In your `host-dns` container, run the following:
 
 ```bash
 root@host-dns:/# netstat -lnp
@@ -192,7 +192,7 @@ Here's what this is telling us overall, what software is listening for what type
 
 1. Proto. This indicates [tcp](../../glossary.md#tcp-transmission-control-protocol) or [udp](../../glossary.md#udp-user-datagram-protocol).
 2. Local Address: You'll see an IP address followed by a port (`:` and a number).
-   * IP address: This is address that the software that is listening is listening on. This will typically be the one and only external IP address that the machine has (in our case, `2.0.0.107`). However, you may also see an IP address that starts with `127`. In that case, the machine is *only* listening for connections from sources that are **internal** to the machine and isn't listening for connections from the overall network.
+   * IP address: This is address that the software that is listening is listening on. This will typically be the one and only external IP address that the machine has (in our case, `2.0.0.107`). However, you may also see an IP address that starts with `127`. In that case, the machine is _only_ listening for connections from sources that are **internal** to the machine and isn't listening for connections from the overall network.
    * Port: You see port `53` for both `TCP` and `UDP` protocols. As you may recall from other chapters, port `53` is the standard port used for `DNS` requests.
 3. PID/Program name: mostly what we see here is `21/knotd` (**NOTE:** This might be a different number on your host-dns machine, that's okay). This means that the program that is listening on this network port is "knotd" (which stands for knot daemon), and it's process-id is `21`. The process ID is useful if you ever want to stop and restart the daemon (by running the `kill <process-id>` command).
 
@@ -219,7 +219,7 @@ nameserver 127.0.0.11
 options edns0 trust-ad ndots:0
 ```
 
-This configuration file is generated for you by Docker, because it's trying to be "helpful." The IP address for the nameserver (`127.0.0.11`) is the one that Docker set up for you to provide name-services for all your docker containers. This IP address may look familiar to you from the `netstat` output we just looked at. *IT WAS DOCKER THE WHOLE TIME.*
+This configuration file is generated for you by Docker, because it's trying to be "helpful." The IP address for the nameserver (`127.0.0.11`) is the one that Docker set up for you to provide name-services for all your docker containers. This IP address may look familiar to you from the `netstat` output we just looked at. _IT WAS DOCKER THE WHOLE TIME._
 
 But we don't want Docker's nonsense because we're doing this _ourselves._ 💪🏼💪🏼💪🏼
 
@@ -227,7 +227,7 @@ Let's edit that IP address, changing it from `127.0.0.11` to `2.0.0.107`. This w
 
 ## See it working
 
-Sweet! We got our Knot DNS daemon up and running. AND we are using that daemon on the `host-dns` machine to answer name-resolution queries for us. Let's test it by running a [dig](../../000-getting-started/command-reference-guide.md) command and see what we get back:
+Sweet! We got our Knot DNS daemon up and running. AND we are using that daemon on the `host-dns` machine to answer name-resolution queries for us. Let's test it by running a [dig](../../command-reference-guide.md#dig) command and see what we get back:
 
 ```bash
 root@host-dns:/# dig host-a.byoi.net


### PR DESCRIPTION
- update links to the command-reference guide
- add links where they were missing